### PR TITLE
Error out when not meeting valid usage

### DIFF
--- a/bin/certg
+++ b/bin/certg
@@ -36,7 +36,7 @@ import certg
 
 if len(sys.argv) != 2:
     print("Usage: certg <config.yaml>")
-    exit()
+    exit(1)
 
 with open(sys.argv[1], 'rt', encoding='utf8') as fh:
     config = yaml.load(fh)


### PR DESCRIPTION
It is custom to not exit with 0 when something went wrong, including not respecting the usage.